### PR TITLE
docs: add Drupal AI section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,6 +14,7 @@ Want to add/edit a link. Please follow the [Contribution guidelines](contributin
 
 ## Contents<!-- omit from toc -->
 
+- [AI](#ai)
 - [Books](#books)
 - [Certifications](#certifications)
 - [Chatting channels](#chatting-channels)
@@ -65,6 +66,17 @@ Want to add/edit a link. Please follow the [Contribution guidelines](contributin
 - [Similar projects](#similar-projects)
 
 ---
+
+## AI
+
+- [Drupal AI](https://www.drupal.org/project/ai) - Integrates generative AI services into Drupal.
+- [Drupal AI Initiative](https://www.drupal.org/about/starshot/initiatives/ai) - Starshot initiative exploring AI capabilities in Drupal.
+- [AI Initiative project](https://www.drupal.org/project/ai_initiative) - Hub for collaboration around AI features.
+- [Drupal AI landing page](https://new.drupal.org/ai) - Overview of Drupal's AI efforts.
+
+<!--lint disable double-link-->
+Back to [TOC](#contents)
+<!--lint enable double-link-->
 
 ## Books
 


### PR DESCRIPTION
## Summary
- add Drupal AI section with links to key initiatives and resources
- update table of contents

## Testing
- `npx awesome-lint` *(fails: 403 Forbidden retrieving package)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2a70273883269db052ebad90cc36